### PR TITLE
feat: read args from env vars with UCANTO_NAME_ prefix

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -101,15 +101,14 @@ export async function start(
  * Run a server
  */
 export async function main() {
-  const argv = await yargs(hideBin(process.argv)).argv;
+  const argv = await yargs(hideBin(process.argv)).env("UCANTO_NAME").argv;
   console.log({ argv });
   const { stop, urls, nameService } = await start(undefined, {
     control: {
       port: argv.controlPort ? Number(argv.controlPort) : 0,
     },
     data: {
-      port: argv.dataPort ? Number(argv.dataPort) : 
-        process.env.PORT ? Number(process.env.PORT) : 0,
+      port: argv.dataPort ? Number(argv.dataPort) : 0,
     },
   });
   function handleExit(signal: string) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,7 +108,8 @@ export async function main() {
       port: argv.controlPort ? Number(argv.controlPort) : 0,
     },
     data: {
-      port: argv.dataPort ? Number(argv.dataPort) : 0,
+      port: argv.dataPort ? Number(argv.dataPort) : 
+        process.env.PORT ? Number(process.env.PORT) : 0,
     },
   });
   function handleExit(signal: string) {


### PR DESCRIPTION
This lets us set args via environment variables by setting e.g. `UCANTO_NAME_DATAPORT` to set the `dataPort` cli arg. This seems like the easiest way to smuggle args into glitch :)